### PR TITLE
Add initial Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+---
+dist: trusty
+cache: pip
+sudo: required
+language: python
+python:
+  - "3.6"
+
+services:
+  - docker
+
+before_install:
+  - sudo apt-get install shellcheck
+  - sudo pip install yamllint
+  - git clone https://github.com/IBM/pattern-ci
+
+before_script:
+  - "./pattern-ci/tests/shellcheck-lint.sh"
+  - "./pattern-ci/tests/yaml-lint.sh"
+
+jobs:
+  include:
+    - script: ./tests/docker-compose.sh
+    - services:
+        - mongodb
+        - docker
+      script: ./tests/local-py.sh
+# - install: ./pattern-ci/scripts/install-minikube.sh
+#   script: echo "Insert a test script that would use yaml files"

--- a/deploy-mongodb.yml
+++ b/deploy-mongodb.yml
@@ -1,3 +1,4 @@
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -11,10 +12,10 @@ spec:
         version: v1
     spec:
       containers:
-      - image: mongo
-        name: mongo
-        ports:
-          - containerPort: 27017
+        - image: mongo
+          name: mongo
+          ports:
+            - containerPort: 27017
 ---
 apiVersion: v1
 kind: Service

--- a/deploy-webapp.yml
+++ b/deploy-webapp.yml
@@ -1,3 +1,4 @@
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -11,10 +12,10 @@ spec:
         version: v1
     spec:
       containers:
-      - name: worklog
-        image: maxshapiro32/worklog
-        ports:
-          - containerPort: 5000
+        - name: worklog
+          image: maxshapiro32/worklog
+          ports:
+            - containerPort: 5000
 ---
 apiVersion: v1
 kind: Service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,19 @@
+---
 version: '3.3'
 
 services:
   mongo:
     container_name: mongo
     ports:
-    - "27017:27017"
+      - "27017:27017"
     image: mongo
     restart: always
 
   web:
     build: ./web
     ports:
-    - "5000:5000"
+      - "5000:5000"
     volumes:
-    - .:/code
+      - .:/code
     depends_on:
-    - mongo
+      - mongo

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,530 @@
+'''
+Created on Sep 7, 2018
+
+@author: MaxShapiro32@ibm.com
+'''
+
+import unittest
+from web import app
+from flask_pymongo import PyMongo
+import json
+
+class TestScenarios(unittest.TestCase):
+    def setUp(self):
+        app.mongoCredentials = PyMongo(app.app, uri="mongodb://localhost:27017/credentials")
+        app.mongoLog = PyMongo(app.app, uri="mongodb://localhost:27017/log")
+        self.app = app.app.test_client()
+        self.app.testing = True
+
+    def tearDown(self):
+        app.mongoLog.cx.drop_database('log')
+
+    def test_create_user(self):
+
+        print("Test Create User")
+
+        '''Create New User'''
+        response = self.app.put('http://localhost:5000/user/create',
+                                data=json.dumps({"username": "test", "password": "abc"}),
+                                content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+
+        '''Creating New User with Existing User Name'''
+        response = self.app.put('http://localhost:5000/user/create',
+                                data=json.dumps({"username": "test", "password": "abc"}),
+                                content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+
+        '''Invalid User Creating'''
+        response = self.app.put('http://localhost:5000/user/create',
+                                data=json.dumps({"password": "abc"}),
+                                content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+
+    def test_login(self):
+
+        print("Test Login")
+
+        '''Create New User'''
+        self.app.put('http://localhost:5000/user/create',
+                                data=json.dumps({"username": "test", "password": "abc"}),
+                                content_type='application/json')
+
+        '''Successful Login'''
+        response = self.app.post('http://localhost:5000/login',
+                                data=json.dumps({"username": "test", "password": "abc"}),
+                                content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+
+        '''Invalid Login'''
+        response = self.app.post('http://localhost:5000/login',
+                                data=json.dumps({"username": "test", "password": "123"}),
+                                content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+
+    def test_reset_password(self):
+
+        print("Test Reset Password")
+
+        '''Create New User'''
+        self.app.put('http://localhost:5000/user/create',
+                                data=json.dumps({"username": "test", "password": "abc"}),
+                                content_type='application/json')
+
+        '''Successful Password Reset'''
+        response = self.app.put('http://localhost:5000/user/test/password/reset',
+                                data=json.dumps({"new_password": "123", "password": "abc"}),
+                                content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+
+        '''Failed Password Reset'''
+        response = self.app.put('http://localhost:5000//user/test/password/reset',
+                                data=json.dumps({"new_password": "123", "password": "abc"}),
+                                content_type='application/json')
+        self.assertEqual(response.status_code, 403)
+
+    def test_year(self):
+
+        print("Test Year")
+
+        '''Create New User'''
+        self.app.put('http://localhost:5000/user/create',
+                                data=json.dumps({"username": "test", "password": "abc"}),
+                                content_type='application/json')
+
+        '''Create Test Data'''
+        self.app.post('http://localhost:5000/user/test/year/2018/office/1')
+
+        '''Year Data Exists'''
+        response = self.app.get('http://localhost:5000/user/test/year/2018')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['office'],1)
+
+        '''Year Data Does Not Exist'''
+        response = self.app.get('http://localhost:5000/user/test/year/2017')
+        self.assertEqual(response.status_code, 404)
+
+        '''Invalid Year'''
+        response = self.app.get('http://localhost:5000/user/test/year/not2018')
+        self.assertEqual(response.status_code, 400)
+
+        '''Not Logged In'''
+        response = self.app.get('http://localhost:5000/user/test2/year/2018')
+        self.assertEqual(response.status_code, 403)
+
+    def test_total(self):
+
+        print("Test Total")
+
+        '''Create New User'''
+        self.app.put('http://localhost:5000/user/create',
+                                data=json.dumps({"username": "test", "password": "abc"}),
+                                content_type='application/json')
+
+        '''Create Test Data'''
+        self.app.post('http://localhost:5000/user/test/year/2018/office/1')
+
+        '''Total Data Exists'''
+        response = self.app.get('http://localhost:5000/user/test/year/2018/total')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['total'],1)
+
+        '''Total Data Does Not Exist'''
+        response = self.app.get('http://localhost:5000/user/test/year/2017/total')
+        self.assertEqual(response.status_code, 404)
+
+        '''Invalid Year'''
+        response = self.app.get('http://localhost:5000/user/test/year/not2018/total')
+        self.assertEqual(response.status_code, 400)
+
+        '''Not Logged In'''
+        response = self.app.get('http://localhost:5000/user/test2/year/2018/total')
+        self.assertEqual(response.status_code, 403)
+
+    def test_office(self):
+
+        print("Test Office")
+
+        '''Updating Office'''
+
+        '''Create New User'''
+        self.app.put('http://localhost:5000/user/create',
+                                data=json.dumps({"username": "test", "password": "abc"}),
+                                content_type='application/json')
+
+        '''Create Test Data'''
+        response = self.app.post('http://localhost:5000/user/test/year/2017/office/1')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['office'],1)
+
+        '''Update Test Data'''
+        response = self.app.post('http://localhost:5000/user/test/year/2017/office/1')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['office'],2)
+
+        '''Invalid Year'''
+        response = self.app.post('http://localhost:5000/user/test/year/not2017/office/1')
+        self.assertEqual(response.status_code, 400)
+
+        '''Invalid Office Total'''
+        response = self.app.post('http://localhost:5000/user/test/year/2017/office/400')
+        self.assertEqual(response.status_code, 400)
+
+        '''Not Logged In'''
+        response = self.app.post('http://localhost:5000/user/test2/year/2017/office/1')
+        self.assertEqual(response.status_code, 403)
+
+        '''Viewing Office'''
+
+        '''Office Data Exists'''
+        response = self.app.get('http://localhost:5000/user/test/year/2017/office')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['office'],2)
+
+        '''No Year Found'''
+        response = self.app.get('http://localhost:5000/user/test/year/2018/office')
+        self.assertEqual(response.status_code, 404)
+
+        '''Invalid Year'''
+        response = self.app.get('http://localhost:5000/user/test/year/not2017/office')
+        self.assertEqual(response.status_code, 400)
+
+        '''Not Logged In'''
+        response = self.app.get('http://localhost:5000/user/test2/year/2017/office')
+        self.assertEqual(response.status_code, 403)
+
+        '''Reset Office'''
+
+        '''Reset Test Data'''
+        response = self.app.put('http://localhost:5000/user/test/year/2017/office/1',
+                                data=json.dumps({"startdate": {"month":2,"day":1}}),
+                                content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['office'],1)
+
+        '''No Year Found'''
+        response = self.app.put('http://localhost:5000/user/test/year/2018/office/1')
+        self.assertEqual(response.status_code, 404)
+
+        '''Invalid Year'''
+        response = self.app.put('http://localhost:5000/user/test/year/not2017/office/1')
+        self.assertEqual(response.status_code, 400)
+
+        '''Invalid Office Total'''
+        response = self.app.put('http://localhost:5000/user/test/year/2017/office/400')
+        self.assertEqual(response.status_code, 400)
+
+        '''Not Logged In'''
+        response = self.app.put('http://localhost:5000/user/test2/year/2017/office/1')
+        self.assertEqual(response.status_code, 403)
+
+    def test_remote(self):
+
+        print("Test Remote")
+
+        '''Updating Remote'''
+
+        '''Create New User'''
+        self.app.put('http://localhost:5000/user/create',
+                                data=json.dumps({"username": "test", "password": "abc"}),
+                                content_type='application/json')
+
+        '''Create Test Data'''
+        response = self.app.post('http://localhost:5000/user/test/year/2017/remote/location/New York/1')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['remote']['locations']['New York'],1)
+
+        '''Update Test Data'''
+        response = self.app.post('http://localhost:5000/user/test/year/2017/remote/location/New York/1')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['remote']['locations']['New York'],2)
+
+        '''Invalid Year'''
+        response = self.app.post('http://localhost:5000/user/test/year/not2017/remote/location/New York/1')
+        self.assertEqual(response.status_code, 400)
+
+        '''Invalid Remote Total'''
+        response = self.app.post('http://localhost:5000/user/test/year/2017/remote/location/New York/400')
+        self.assertEqual(response.status_code, 400)
+
+        '''Not Logged In'''
+        response = self.app.post('http://localhost:5000/user/test2/year/2017/remote/location/New York/1')
+        self.assertEqual(response.status_code, 403)
+
+        '''Viewing Remote'''
+
+        '''Office Data Exists'''
+        response = self.app.get('http://localhost:5000/user/test/year/2017/remote')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['remote']['total'],2)
+
+        '''No Year Found'''
+        response = self.app.get('http://localhost:5000/user/test/year/2018/remote')
+        self.assertEqual(response.status_code, 404)
+
+        '''Invalid Year'''
+        response = self.app.get('http://localhost:5000/user/test/year/not2017/remote')
+        self.assertEqual(response.status_code, 400)
+
+        '''Not Logged In'''
+        response = self.app.get('http://localhost:5000/user/test2/year/2017/remote')
+        self.assertEqual(response.status_code, 403)
+
+        '''Reset Remote'''
+
+        '''Reset Test Data'''
+        response = self.app.put('http://localhost:5000/user/test/year/2017/remote/location/New York/1',
+                                data=json.dumps({"startdate": {"month":2,"day":1}}),
+                                content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['remote']['locations']['New York'],1)
+
+        '''No Year Found'''
+        response = self.app.put('http://localhost:5000/user/test/year/2018/remote/location/New York/1')
+        self.assertEqual(response.status_code, 404)
+
+        '''Invalid Year'''
+        response = self.app.put('http://localhost:5000/user/test/year/not2017/remote/location/New York/1')
+        self.assertEqual(response.status_code, 400)
+
+        '''Invalid Remote Total'''
+        response = self.app.put('http://localhost:5000/user/test/year/2017/remote/location/New York/400')
+        self.assertEqual(response.status_code, 400)
+
+        '''Not Logged In'''
+        response = self.app.put('http://localhost:5000/user/test2/year/2017/remote/location/New York/1')
+        self.assertEqual(response.status_code, 403)
+
+    def test_vacation(self):
+
+        print("Test Vacation")
+
+        '''Updating Vacation'''
+
+        '''Create New User'''
+        self.app.put('http://localhost:5000/user/create',
+                                data=json.dumps({"username": "test", "password": "abc"}),
+                                content_type='application/json')
+
+        '''Create Test Data'''
+        response = self.app.post('http://localhost:5000/user/test/year/2017/vacation/1')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['vacation'],1)
+
+        '''Update Test Data'''
+        response = self.app.post('http://localhost:5000/user/test/year/2017/vacation/1')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['vacation'],2)
+
+        '''Invalid Year'''
+        response = self.app.post('http://localhost:5000/user/test/year/not2017/vacation/1')
+        self.assertEqual(response.status_code, 400)
+
+        '''Invalid Vacation Total'''
+        response = self.app.post('http://localhost:5000/user/test/year/2017/vacation/400')
+        self.assertEqual(response.status_code, 400)
+
+        '''Not Logged In'''
+        response = self.app.post('http://localhost:5000/user/test2/year/2017/vacation/1')
+        self.assertEqual(response.status_code, 403)
+
+        '''Viewing Vacation'''
+
+        '''Vacation Data Exists'''
+        response = self.app.get('http://localhost:5000/user/test/year/2017/vacation')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['vacation'],2)
+
+        '''No Year Found'''
+        response = self.app.get('http://localhost:5000/user/test/year/2018/vacation')
+        self.assertEqual(response.status_code, 404)
+
+        '''Invalid Year'''
+        response = self.app.get('http://localhost:5000/user/test/year/not2017/vacation')
+        self.assertEqual(response.status_code, 400)
+
+        '''Not Logged In'''
+        response = self.app.get('http://localhost:5000/user/test2/year/2017/vacation')
+        self.assertEqual(response.status_code, 403)
+
+        '''Reset Vacation'''
+
+        '''Reset Test Data'''
+        response = self.app.put('http://localhost:5000/user/test/year/2017/vacation/1',
+                                data=json.dumps({"startdate": {"month":2,"day":1}}),
+                                content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['vacation'],1)
+
+        '''No Year Found'''
+        response = self.app.put('http://localhost:5000/user/test/year/2018/vacation/1')
+        self.assertEqual(response.status_code, 404)
+
+        '''Invalid Year'''
+        response = self.app.put('http://localhost:5000/user/test/year/not2017/vacation/1')
+        self.assertEqual(response.status_code, 400)
+
+        '''Invalid Vacation Total'''
+        response = self.app.put('http://localhost:5000/user/test/year/2017/vacation/400')
+        self.assertEqual(response.status_code, 400)
+
+        '''Not Logged In'''
+        response = self.app.put('http://localhost:5000/user/test2/year/2017/vacation/1')
+        self.assertEqual(response.status_code, 403)
+
+    def test_holidays(self):
+
+        print("Test Holidays")
+
+        '''Updating Holidays'''
+
+        '''Create New User'''
+        self.app.put('http://localhost:5000/user/create',
+                                data=json.dumps({"username": "test", "password": "abc"}),
+                                content_type='application/json')
+
+        '''Create Test Data'''
+        response = self.app.post('http://localhost:5000/user/test/year/2017/holidays/1')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['holidays'],1)
+
+        '''Update Test Data'''
+        response = self.app.post('http://localhost:5000/user/test/year/2017/holidays/1')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['holidays'],2)
+
+        '''Invalid Year'''
+        response = self.app.post('http://localhost:5000/user/test/year/not2017/holidays/1')
+        self.assertEqual(response.status_code, 400)
+
+        '''Invalid Holidays Total'''
+        response = self.app.post('http://localhost:5000/user/test/year/2017/holidays/400')
+        self.assertEqual(response.status_code, 400)
+
+        '''Not Logged In'''
+        response = self.app.post('http://localhost:5000/user/test2/year/2017/holidays/1')
+        self.assertEqual(response.status_code, 403)
+
+        '''Viewing Holidays'''
+
+        '''Holidays Data Exists'''
+        response = self.app.get('http://localhost:5000/user/test/year/2017/holidays')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['holidays'],2)
+
+        '''No Year Found'''
+        response = self.app.get('http://localhost:5000/user/test/year/2018/holidays')
+        self.assertEqual(response.status_code, 404)
+
+        '''Invalid Year'''
+        response = self.app.get('http://localhost:5000/user/test/year/not2017/holidays')
+        self.assertEqual(response.status_code, 400)
+
+        '''Not Logged In'''
+        response = self.app.get('http://localhost:5000/user/test2/year/2017/holidays')
+        self.assertEqual(response.status_code, 403)
+
+        '''Reset Holidays'''
+
+        '''Reset Test Data'''
+        response = self.app.put('http://localhost:5000/user/test/year/2017/holidays/1',
+                                data=json.dumps({"startdate": {"month":2,"day":1}}),
+                                content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['holidays'],1)
+
+        '''No Year Found'''
+        response = self.app.put('http://localhost:5000/user/test/year/2018/holidays/1')
+        self.assertEqual(response.status_code, 404)
+
+        '''Invalid Year'''
+        response = self.app.put('http://localhost:5000/user/test/year/not2017/holidays/1')
+        self.assertEqual(response.status_code, 400)
+
+        '''Invalid Holidays Total'''
+        response = self.app.put('http://localhost:5000/user/test/year/2017/holidays/400')
+        self.assertEqual(response.status_code, 400)
+
+        '''Not Logged In'''
+        response = self.app.put('http://localhost:5000/user/test2/year/2017/holidays/1')
+        self.assertEqual(response.status_code, 403)
+
+    def test_sick(self):
+
+        print("Test Sick")
+
+        '''Updating Sick'''
+
+        '''Create New User'''
+        self.app.put('http://localhost:5000/user/create',
+                                data=json.dumps({"username": "test", "password": "abc"}),
+                                content_type='application/json')
+
+        '''Create Test Data'''
+        response = self.app.post('http://localhost:5000/user/test/year/2017/sick/1')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['sick'],1)
+
+        '''Update Test Data'''
+        response = self.app.post('http://localhost:5000/user/test/year/2017/sick/1')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['sick'],2)
+
+        '''Invalid Year'''
+        response = self.app.post('http://localhost:5000/user/test/year/not2017/sick/1')
+        self.assertEqual(response.status_code, 400)
+
+        '''Invalid Sick Total'''
+        response = self.app.post('http://localhost:5000/user/test/year/2017/sick/400')
+        self.assertEqual(response.status_code, 400)
+
+        '''Not Logged In'''
+        response = self.app.post('http://localhost:5000/user/test2/year/2017/sick/1')
+        self.assertEqual(response.status_code, 403)
+
+        '''Viewing Sick'''
+
+        '''Sick Data Exists'''
+        response = self.app.get('http://localhost:5000/user/test/year/2017/sick')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['sick'],2)
+
+        '''No Year Found'''
+        response = self.app.get('http://localhost:5000/user/test/year/2018/sick')
+        self.assertEqual(response.status_code, 404)
+
+        '''Invalid Year'''
+        response = self.app.get('http://localhost:5000/user/test/year/not2017/sick')
+        self.assertEqual(response.status_code, 400)
+
+        '''Not Logged In'''
+        response = self.app.get('http://localhost:5000/user/test2/year/2017/sick')
+        self.assertEqual(response.status_code, 403)
+
+        '''Reset Sick'''
+
+        '''Reset Test Data'''
+        response = self.app.put('http://localhost:5000/user/test/year/2017/sick/1',
+                                data=json.dumps({"startdate": {"month":2,"day":1}}),
+                                content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['sick'],1)
+
+        '''No Year Found'''
+        response = self.app.put('http://localhost:5000/user/test/year/2018/sick/1')
+        self.assertEqual(response.status_code, 404)
+
+        '''Invalid Year'''
+        response = self.app.put('http://localhost:5000/user/test/year/not2017/sick/1')
+        self.assertEqual(response.status_code, 400)
+
+        '''Invalid Sick Total'''
+        response = self.app.put('http://localhost:5000/user/test/year/2017/sick/400')
+        self.assertEqual(response.status_code, 400)
+
+        '''Not Logged In'''
+        response = self.app.put('http://localhost:5000/user/test2/year/2017/sick/1')
+        self.assertEqual(response.status_code, 403)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/docker-compose.sh
+++ b/tests/docker-compose.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+# shellcheck disable=SC1090
+source "$(dirname "$0")"/../pattern-ci/scripts/resources.sh
+
+main(){
+    if ! docker-compose up -d; then
+        test_failed "$0"
+    elif ! docker-compose ps; then
+        test_failed "$0"
+    elif ! sleep 1 && curl -X PUT -H 'Content-type: application/json' -d '{"username":"admin","password":"test"}' localhost:5000/user/create; then
+        test_failed "$0"
+    else
+        test_passed "$0"
+    fi
+}
+
+main "$@"

--- a/tests/local-py.sh
+++ b/tests/local-py.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+
+# shellcheck disable=SC1090
+source "$(dirname "$0")"/../pattern-ci/scripts/resources.sh
+
+main(){
+    if ! pip install -r web/requirements.txt; then
+        test_failed "$0"
+    elif ! python tests.py -v; then
+        test_failed "$0"
+    else
+        test_passed "$0"
+    fi
+}
+
+main "$@"

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,9 +1,8 @@
-FROM ubuntu:latest
+FROM python:3.7-alpine
 MAINTAINER Max Shapiro "maxshapiro32@ibm.com"
-RUN apt-get update -y
-RUN apt-get install -y python3-pip python-dev build-essential
+RUN apk add gcc g++ make libffi-dev openssl-dev
 COPY . /app
 WORKDIR /app
-RUN pip3 install -r requirements.txt
-ENTRYPOINT ["python3"]
+RUN pip install -r requirements.txt
+ENTRYPOINT ["python"]
 CMD ["app.py"]


### PR DESCRIPTION
This commit adds in an initial CI. Some CI scripts are pulled from the
IBM/pattern-ci repo. This commit adds CI in the following:
* Linters for Shell and YAML files
* Tests docker-compose yaml and one service endpoint
* Tests REST APIs using Flask unit Tests
  * Modified tests.py to be used in command line
  * Modified tests.py to use local mongo instead
    of recreating mongo containers on each test.
    Mongo database is dropped after each test case.

This commit modified YAML files to pass the YAML linter.

This commit adds __init__.py in web folder so that tests.py can
import it.

This commit modifies The Dockerfile in the flask app. The base image is
now using python alpine image instead of ubuntu. This reduces the total
image size of the app.

Signed-off-by: AnthonyAmanse <ghieamanse@gmail.com>